### PR TITLE
Add persistentTabBar property in TabBar documentation

### DIFF
--- a/content/widgets/tabbar.md
+++ b/content/widgets/tabbar.md
@@ -11,6 +11,7 @@ The TabBar Widget enables the creation of tab bars, providing a convenient and v
 | styles        | object  | [See properties](#styles)                |
 | selectedIndex | integer | Selecting a Tab based on its index order |
 | items         | array   | Define each of your Tab here             |
+| persistentTabBar | boolean | Keep the TabBar header fixed while the selected tab body content scrolls. Only applies to the full `TabBar` container, not `TabBarOnly`. |
 | onTabSelection | action | The action that will be performed when a tab is pressed. |
 | onTabSelectionHaptic | enum | The type of haptic to perform when a tab is pressed. It should be one of heavyImpact, mediumImpact, lightImpact, selectionClick, and vibrate |
 


### PR DESCRIPTION
PR Summary
Add documentation for the new `persistentTabBar` property in the TabBar widget.

What changed
Updated tabbar.md
Added `persistentTabBar` to the TabBar properties table
Explained that it keeps the header fixed and only applies to full `TabBar`, not `TabBarOnly`

Why
This documents the new persistent header behavior introduced in the TabBar implementation
